### PR TITLE
Change dev ridibooks host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 RIDI_PAY_HOST=pay.local.ridi.io
 RIDI_PAY_API_SERVER_HOST=pay-api.local.ridi.io
-RIDIBOOKS_HOST=master.test.ridi.io
+RIDIBOOKS_HOST=dev.ridi.io
 ACCOUNT_SERVER_HOST=account.dev.ridi.io
 OAUTH2_CLIENT_ID=Nkt2Xdc0zMuWmye6MSkYgqCh9q6JjeMCsUiH1kgL

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       env:
         - RIDI_PAY_HOST=pay.ridi.io
         - RIDI_PAY_API_SERVER_HOST=pay-api.dev.ridi.io
-        - RIDIBOOKS_HOST=master.test.ridi.io
+        - RIDIBOOKS_HOST=dev.ridi.io
         - ACCOUNT_SERVER_HOST=account.dev.ridi.io
         - OAUTH2_CLIENT_ID=${DEV_OAUTH2_CLIENT_ID}
         - S3_BUCKET_NAME=ridi-pay-frontend-test


### PR DESCRIPTION
master.test.ridi.io가 지금은 운영되고 있지 않아서 dev.ridi.io로 대체합니다.