### PR TITLE
feat: @sentry/browser 패키지 버전 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@ridi/event-tracker": "^0.7.0",
     "@ridi/object-case-converter": "^2.0.0-alpha",
     "@ridi/rsg": "2.0.15",
-    "@sentry/browser": "4.2.1",
+    "@sentry/browser": "4.3.4",
     "@types/url-parse": "^1.4.3",
     "@types/webfontloader": "^1.6.29",
     "axios": "0.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,52 +905,57 @@
   dependencies:
     tslint-react "^3.4.0"
 
-"@sentry/browser@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-4.2.1.tgz#39cc64e79e3f7bfed5256f9b07ae81a3a0e7e079"
-  integrity sha512-jOQ+RroroGqgJFhgYxyqa+ENeZneug+A4cBmYLeSoLVYmk2xGrJBXes2jEH6eHjDSjVKgZlM+lvERNeqIa6/Fw==
+"@sentry/browser@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-4.3.4.tgz#5c17184781c4fb6ad8ab48f5c48e01630d4fc3dc"
+  integrity sha512-odRXxnhcSYzyR4YvTolNEyrz3fdDVw308l+9RBRJA9yOFVlezaz1mXH6Gv00F7cIj9yE/JtezDyhP339WsWy3w==
   dependencies:
-    "@sentry/core" "4.2.1"
-    "@sentry/types" "4.2.1"
-    "@sentry/utils" "4.2.1"
+    "@sentry/core" "4.3.4"
+    "@sentry/types" "4.3.4"
+    "@sentry/utils" "4.3.4"
+    tslib "^1.9.3"
 
-"@sentry/core@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.2.1.tgz#156b1fa03ebc8dbc9e13bdf162631bdae6fb110e"
-  integrity sha512-gU2y0iO2zJqhPCazq3L0q/yfhkja3kB7AxBGrhYdVW/k3JN2dpokAu+VkHDDHYfrPm+SDAjdVWJNpo47WV/fFw==
+"@sentry/core@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.3.4.tgz#414e050b9e963ac7f839331ad33590e59d883988"
+  integrity sha512-KwolQmAnXiFMeXBuxPUM8fW+2bOICdHfpjdf83qD7WSeuKqGvXhxXyApWNSLE+l2DPO6/8UKnIGmR8bEn0G7QA==
   dependencies:
-    "@sentry/hub" "4.2.1"
-    "@sentry/minimal" "4.2.1"
-    "@sentry/types" "4.2.1"
-    "@sentry/utils" "4.2.1"
+    "@sentry/hub" "4.3.4"
+    "@sentry/minimal" "4.3.4"
+    "@sentry/types" "4.3.4"
+    "@sentry/utils" "4.3.4"
+    tslib "^1.9.3"
 
-"@sentry/hub@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-4.2.1.tgz#8adfe7657e69a60c1689e10a98b89f3c664e7e25"
-  integrity sha512-YXLMxepptx/6RkszgeVEhyUNCFsXbhXO+bS411PMFzRBBLUoJGis60JENNTjnmuuNnLcmz+HmpubQr3ygGrcLw==
+"@sentry/hub@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-4.3.4.tgz#48915f5867e8ef1d964c89394e8500d1d050719b"
+  integrity sha512-vaBGCnhinLB8N4aQLMiPPhnlTkIUwU/dxWzw/xsuKY3MYWrmfMUyWgMZF60Mz3B4F0lW1lsg5jnJz9xPnjZowg==
   dependencies:
-    "@sentry/types" "4.2.1"
-    "@sentry/utils" "4.2.1"
+    "@sentry/types" "4.3.4"
+    "@sentry/utils" "4.3.4"
+    tslib "^1.9.3"
 
-"@sentry/minimal@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.2.1.tgz#bdd5f2bbf6ea6981b9e7b8a36aa5224aa36f9693"
-  integrity sha512-VmwOzWXa1Z8mFMx3k9+8jIK8ExWVmU48SItD4IsxXQx1jL5ECIxpIpt4n4LWKp00VJ2AcwjpHJM+ShIFHUqubg==
+"@sentry/minimal@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.3.4.tgz#8375c3d040621dd30eeddaebf4ef1bf22be0f643"
+  integrity sha512-EBmQgdAQgxkhWFsBO4TmsP3cg5yTzg48HmPe3Dyt7PtF5Umw3DFW6qboAqnN1+KF+pHNuxkqevvgBTFp7b4Saw==
   dependencies:
-    "@sentry/hub" "4.2.1"
-    "@sentry/types" "4.2.1"
+    "@sentry/hub" "4.3.4"
+    "@sentry/types" "4.3.4"
+    tslib "^1.9.3"
 
-"@sentry/types@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.2.1.tgz#b0b290f0021d1ce005eac864ff4740578afad379"
-  integrity sha512-9Fo2QQi2+QfxlnaqQm60OfRRg/R2Ks9v4uxeEeQhj9NanhUXFu2+SBS7LJGG/upYGWxDXejyhu4XM/H3kXUdyw==
+"@sentry/types@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.3.4.tgz#563f9def51da301cfd474ecf35ae4d97847aed61"
+  integrity sha512-qsqrcyNilpbzYjqef+km0Grh5BckSFD4MUdJDNkUE5XU/ImniYddj18bMDlQxluJlTPDjUFQ37FXtEmxLeOwkQ==
 
-"@sentry/utils@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.2.1.tgz#8ea2bf2c2ee8bbe85b94df4834eb3b3ae2c3d034"
-  integrity sha512-e2EaWa1Re8MC9FHNH81OqzuN01eBV1eTqyi83wgluRKx8iDf+3HvWG8mfuccBR/67Ae6h+KoNt+cKVHExsLzcA==
+"@sentry/utils@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.3.4.tgz#4473d9f4d1b909e51b6aea7051ebe1bd838d56e9"
+  integrity sha512-CMGMdIv5RHUCKRF4aWPZ/gFRTfBQpLVVJEGCeFGZLXHBdpgQac0lf3jlu8sND0KZ0S3C5x3tGS/eEqmOZRQ/pw==
   dependencies:
-    "@sentry/types" "4.2.1"
+    "@sentry/types" "4.3.4"
+    tslib "^1.9.3"
 
 "@types/classnames@^2.2.3":
   version "2.2.7"
@@ -9166,6 +9171,11 @@ tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslint-config-prettier@^1.14.0:
   version "1.17.0"


### PR DESCRIPTION
## 작업내용
- [Illegal invocation 에 대한 sentry 오류](https://sentry.io/organizations/ridi/issues/1584990403/?project=1307887&referrer=slack)
- [ReportingObserver API 지원 문제로 의심됨](https://github.com/getsentry/sentry-javascript/issues/1450)
```
"ReportingObserver [deprecation]: Deprecation messages are stored in the devtools-frontend repo at front_end/models/issues_manager/DeprecationIssue.ts."
```
- @sentry/browser 패키지를 ReportingObserver 지원 기능이 추가된 4.3.4 버전으로 업데이트